### PR TITLE
updated page.js in configurator to use new org name

### DIFF
--- a/src/app/configurator/page.js
+++ b/src/app/configurator/page.js
@@ -23,7 +23,7 @@ const getLength = (length) => {
   }
 }
 
-const BASE_URI = 'https://raw.githubusercontent.com/Armchair-Engineering/Archetype/main'
+const BASE_URI = 'https://raw.githubusercontent.com/Armchair-Heavy-Industries/Archetype/main'
 
 const getSelectedFiles = (selections, mods, useSpacer) => {
   const files = []


### PR DESCRIPTION
changed Armchair-Engineering to Armchair-Heavy-Industries

- current link works but it may "expire"  in a few days if github decide to recycle the old name